### PR TITLE
Sync hdt-cpp to latest "develop" commit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.o
 *~
+*.a
 *.so
 *.dylib
 .gdbinit

--- a/Makefile
+++ b/Makefile
@@ -1,34 +1,47 @@
 # Build HDT library for SWI-Prolog
 
-HDTHOME=hdt-cpp/hdt-lib
+HDTHOME=hdt-cpp
+LIBHDT=$(HDTHOME)/libhdt
+LIBCDS=$(HDTHOME)/libcds
+HDTLIB=$(LIBHDT)/.libs
+CDSLIB=$(LIBCDS)/.libs
 SOBJ=	$(PACKSODIR)/hdt4pl.$(SOEXT)
-CFLAGS+=-I$(HDTHOME)/include -g
-LIBS=	-L$(HDTHOME) -lhdt
+NPROC:=$(shell expr $$(nproc) + 1)
+MAKE_J=-j$(NPROC)
+CFLAGS+=-I$(LIBHDT)/include -g
+# This doesn't work because the *.so files get picked first:
+#     LIBS=	-L$(HDTLIB) -L$(CDSLIB) -lhdt -lcds
+# Instead, we copy the *.a files intothe same directory as $(OBJ)
+# - see the rules for $(OBJ2).
+LIBS= -Lc -lhdt -lcds
 OBJ=	c/hdt4pl.o
+OBJ2=	c/libcds.a c/libhdt.a
 LD=g++
 
 all:	$(SOBJ)
 
-$(SOBJ): $(OBJ)
+c/libhdt.a: $(HDTLIB)/libhdt.a
+	ln $(HDTLIB)/libhdt.a c/
+
+c/libcds.a: $(CDSLIB)/libcds.a
+	ln $(CDSLIB)/libcds.a c/
+
+$(SOBJ): $(OBJ) $(OBJ2)
 	mkdir -p $(PACKSODIR)
 	$(LD) $(ARCH) $(LDSOFLAGS) -o $@ $< $(LIBS) $(SWISOLIB) -lserd-0
 
-c/hdt4pl.o: c/hdt4pl.cpp $(HDTHOME)/libhdt.a
+c/hdt4pl.o: c/hdt4pl.cpp $(HDTLIB)/libhdt.a $(CDSLIB)/libcds.a
 	$(CC) $(ARCH) $(CFLAGS) -c -o $@ c/hdt4pl.cpp
 
-$(HDTHOME)/.make-senitel:
-	[ ! -f $(HDTHOME)/Makefile ] || (cd $(HDTHOME) && git reset --hard)
-	git submodule update --init
-	sed -i 's/^FLAGS=-O3/FLAGS=-fPIC -O3/' $(HDTHOME)/Makefile
-	touch $@
+$(HDTLIB)/libhdt.a $(HDTLIB)/libcds.a: FORCE
+	$(MAKE) -C $(HDTHOME) $(MAKE_J)
 
-$(HDTHOME)/libhdt.a: $(HDTHOME)/.make-senitel
-	$(MAKE) -C $(HDTHOME) all
+FORCE:
 
 check::
 install::
 clean:
-	rm -f $(OBJ) $(HDTHOME)/.make-senitel
+	rm -f $(OBJ) $(OBJ2)
 	[ ! -f $(HDTHOME)/Makefile ] || (cd $(HDTHOME) && git reset --hard)
 	[ ! -f $(HDTHOME)/Makefile ] || $(MAKE) -C $(HDTHOME) clean
 

--- a/README.md
+++ b/README.md
@@ -17,15 +17,26 @@ Installation on Windows requires more creativity though.
 
 ## Installation
 
-1. Install a recent version of Serd:
+1. Install a recent version of Serd. One way of doing this
+on Ubuntu is: `sudo apt install libserd-0-0 serdi`
 
+The currently installed version can be found by the command `serdi
+-v`. The minimum version of Serd is 0.28.0 (see `hdt-cpp/README.md` or
+the `before_install` rule in `hdt-cpp/.travis.yml`).
+
+If that isn't available, it can be installed and built by:
 ```bash
-curl -s http://download.drobilla.net/serd-0.26.0.tar.bz2 | tar -xj && \
-  cd serd-0.26.0 && \
-  ./waf configure && \
-  ./waf && \
+curl -s http://download.drobilla.net/serd-0.30.0.tar.bz2 | tar -xj && \
+  cd serd-0.30.0 && \
+  python2 ./waf configure && \
+  python2 ./waf && \
   sudo ./waf install;
 ```
+
+You may wish to specify `--prefix=/usr/local` or `--prefix=$HOME/.local`
+to `waf configure`.
+
+You can uninstall by `python2 ./waf uninstall`
 
 2. Install Raptor2.
 

--- a/configure
+++ b/configure
@@ -1,0 +1,16 @@
+# "configure" calls hdt-cpp's configure with suitable parameters.
+
+# TODO: The git commands should probably be in a "dependencies"
+#       step; however, that requires adding
+#       prolog:build_setp(dependencies, make) to build/make.pl
+
+set -e -x
+
+HDTHOME=hdt-cpp
+
+( [ ! -f ${HDTHOME}/autogen.sh ] || (cd ${HDTHOME} && git reset --hard) )
+git submodule update --init ${HDTHOME}
+
+cd ${HDTHOME}
+./autogen.sh
+./configure --prefix=${HOME}/.local CXXFLAGS='-fPIC -O2 -g' CFLAGS='-fPIC -O2 -g'

--- a/pack.pl
+++ b/pack.pl
@@ -1,5 +1,5 @@
 name(hdt).
-version('0.5').
+version('0.5.1').
 title('Access RDF HDT files').
 keywords(['RDF']).
 author( 'Jan Wielemaker', 'J.Wielemaker@vu.nl' ).

--- a/prolog/hdt.pl
+++ b/prolog/hdt.pl
@@ -90,7 +90,7 @@
 %	collection.  Options:
 %
 %	  - access(+Access)
-%	  How the file is accessed. On of `map` (map the file
+%	  How the file is accessed. One of `map` (map the file
 %	  into memory, default) or `load` (load the content of the
 %	  file).
 %	  - indexed(+Boolean)


### PR DESCRIPTION
- modify Makefile due to the changes

The ".make-sentinel" stuff probably isn't needed, but it follows from the original code (with a correction to the spelling of "senitel").
